### PR TITLE
Changed NotImplementedError to RequiredImplementationMissingError

### DIFF
--- a/lib/active_record/dbt.rb
+++ b/lib/active_record/dbt.rb
@@ -11,7 +11,5 @@ module ActiveRecord
 
       config
     end
-
-    class RequiredImplementationMissingError < StandardError; end
   end
 end

--- a/lib/active_record/dbt.rb
+++ b/lib/active_record/dbt.rb
@@ -11,5 +11,7 @@ module ActiveRecord
 
       config
     end
+
+    class RequiredImplementationMissingError < StandardError; end
   end
 end

--- a/lib/active_record/dbt/column/testable/accepted_values_testable.rb
+++ b/lib/active_record/dbt/column/testable/accepted_values_testable.rb
@@ -5,16 +5,12 @@ module ActiveRecord
     module Column
       module Testable
         module AcceptedValuesTestable
-          REQUIRED_ACCEPTED_VALUES_TESTABLE_METHODS = %i[@config column table_name column_name].freeze
+          extend ActiveRecord::Dbt::RequiredMethods
+
+          define_required_methods :@config, :column, :table_name, :column_name
 
           delegate :type, to: :column, prefix: true
           delegate :add_log, to: :@config
-
-          REQUIRED_ACCEPTED_VALUES_TESTABLE_METHODS.each do |method_name|
-            define_method(method_name) do
-              raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
-            end
-          end
 
           def accepted_values_test
             return nil unless column_type == :boolean || enum_values.present?

--- a/lib/active_record/dbt/column/testable/accepted_values_testable.rb
+++ b/lib/active_record/dbt/column/testable/accepted_values_testable.rb
@@ -12,7 +12,7 @@ module ActiveRecord
 
           REQUIRED_ACCEPTED_VALUES_TESTABLE_METHODS.each do |method_name|
             define_method(method_name) do
-              raise NotImplementedError, "You must implement #{self.class}##{__method__}"
+              raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
             end
           end
 

--- a/lib/active_record/dbt/column/testable/not_null_testable.rb
+++ b/lib/active_record/dbt/column/testable/not_null_testable.rb
@@ -5,13 +5,9 @@ module ActiveRecord
     module Column
       module Testable
         module NotNullTestable
-          REQUIRED_NOT_NULL_TESTABLE_METHODS = %i[column].freeze
+          extend ActiveRecord::Dbt::RequiredMethods
 
-          REQUIRED_NOT_NULL_TESTABLE_METHODS.each do |method_name|
-            define_method(method_name) do
-              raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
-            end
-          end
+          define_required_methods :column
 
           def not_null_test
             column.null == true ? nil : 'not_null'

--- a/lib/active_record/dbt/column/testable/not_null_testable.rb
+++ b/lib/active_record/dbt/column/testable/not_null_testable.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
           REQUIRED_NOT_NULL_TESTABLE_METHODS.each do |method_name|
             define_method(method_name) do
-              raise NotImplementedError, "You must implement #{self.class}##{__method__}"
+              raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
             end
           end
 

--- a/lib/active_record/dbt/column/testable/relationships_testable.rb
+++ b/lib/active_record/dbt/column/testable/relationships_testable.rb
@@ -5,18 +5,14 @@ module ActiveRecord
     module Column
       module Testable
         module RelationshipsTestable
-          REQUIRED_RELATIONSHIPS_TESTABLE_METHODS = %i[@config foreign_keys column_name].freeze
-
           include ActiveRecord::Dbt::DbtPackage::Dbterd::Column::Testable::RelationshipsMetaRelationshipType
+
+          extend ActiveRecord::Dbt::RequiredMethods
+
+          define_required_methods :@config, :foreign_keys, :column_name
 
           delegate :source_name, :data_sync_delayed?, to: :@config
           delegate :to_table, to: :foreign_key
-
-          REQUIRED_RELATIONSHIPS_TESTABLE_METHODS.each do |method_name|
-            define_method(method_name) do
-              raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
-            end
-          end
 
           def relationships_test
             return nil if foreign_key.blank?

--- a/lib/active_record/dbt/column/testable/relationships_testable.rb
+++ b/lib/active_record/dbt/column/testable/relationships_testable.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
           REQUIRED_RELATIONSHIPS_TESTABLE_METHODS.each do |method_name|
             define_method(method_name) do
-              raise NotImplementedError, "You must implement #{self.class}##{__method__}"
+              raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
             end
           end
 

--- a/lib/active_record/dbt/column/testable/unique_testable.rb
+++ b/lib/active_record/dbt/column/testable/unique_testable.rb
@@ -5,13 +5,9 @@ module ActiveRecord
     module Column
       module Testable
         module UniqueTestable
-          REQUIRED_UNIQUE_TESTABLE_METHODS = %i[table_name column_name primary_keys].freeze
+          extend ActiveRecord::Dbt::RequiredMethods
 
-          REQUIRED_UNIQUE_TESTABLE_METHODS.each do |method_name|
-            define_method(method_name) do
-              raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
-            end
-          end
+          define_required_methods :table_name, :column_name, :primary_keys
 
           def unique_test
             unique? ? 'unique' : nil

--- a/lib/active_record/dbt/column/testable/unique_testable.rb
+++ b/lib/active_record/dbt/column/testable/unique_testable.rb
@@ -9,7 +9,7 @@ module ActiveRecord
 
           REQUIRED_UNIQUE_TESTABLE_METHODS.each do |method_name|
             define_method(method_name) do
-              raise NotImplementedError, "You must implement #{self.class}##{__method__}"
+              raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
             end
           end
 

--- a/lib/active_record/dbt/configuration/dwh_platform.rb
+++ b/lib/active_record/dbt/configuration/dwh_platform.rb
@@ -4,13 +4,9 @@ module ActiveRecord
   module Dbt
     module Configuration
       module DwhPlatform
-        REQUIRED_DWH_PLATFORM_METHODS = %i[source_config_path].freeze
+        extend ActiveRecord::Dbt::RequiredMethods
 
-        REQUIRED_DWH_PLATFORM_METHODS.each do |method_name|
-          define_method(method_name) do
-            raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
-          end
-        end
+        define_required_methods :source_config_path
 
         def dwh_platform=(dwh_platform)
           @dwh_platform = validate_dwh_platform(dwh_platform)

--- a/lib/active_record/dbt/configuration/dwh_platform.rb
+++ b/lib/active_record/dbt/configuration/dwh_platform.rb
@@ -4,6 +4,14 @@ module ActiveRecord
   module Dbt
     module Configuration
       module DwhPlatform
+        REQUIRED_DWH_PLATFORM_METHODS = %i[source_config_path].freeze
+
+        REQUIRED_DWH_PLATFORM_METHODS.each do |method_name|
+          define_method(method_name) do
+            raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
+          end
+        end
+
         def dwh_platform=(dwh_platform)
           @dwh_platform = validate_dwh_platform(dwh_platform)
         end

--- a/lib/active_record/dbt/data_type/mapper.rb
+++ b/lib/active_record/dbt/data_type/mapper.rb
@@ -10,6 +10,8 @@ module ActiveRecord
         include ActiveRecord::Dbt::DataType::DwhPlatform::Redshift
         include ActiveRecord::Dbt::DataType::DwhPlatform::Snowflake
 
+        extend ActiveRecord::Dbt::RequiredMethods
+
         # [Platform-specific data types | dbt Developer Hub](https://docs.getdbt.com/reference/resource-properties/data-types)
         RUBY_TO_DWH_PLATFORM_TYPE_MAP = {
           'bigquery' => RUBY_TO_BIGQUERY_TYPES,
@@ -19,15 +21,9 @@ module ActiveRecord
           'spark' => RUBY_TO_SPARK_TYPES
         }.freeze
 
-        REQUIRED_DATATYPE_METHODS = %i[column @config].freeze
+        define_required_methods :column, :@config
 
         delegate :dwh_platform, to: :@config
-
-        REQUIRED_DATATYPE_METHODS.each do |method_name|
-          define_method(method_name) do
-            raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
-          end
-        end
 
         private
 

--- a/lib/active_record/dbt/data_type/mapper.rb
+++ b/lib/active_record/dbt/data_type/mapper.rb
@@ -25,7 +25,7 @@ module ActiveRecord
 
         REQUIRED_DATATYPE_METHODS.each do |method_name|
           define_method(method_name) do
-            raise NotImplementedError, "You must implement #{self.class}##{__method__}"
+            raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
           end
         end
 

--- a/lib/active_record/dbt/dbt_package/dbt_utils/table/testable/unique_combination_of_columns_testable.rb
+++ b/lib/active_record/dbt/dbt_package/dbt_utils/table/testable/unique_combination_of_columns_testable.rb
@@ -7,15 +7,11 @@ module ActiveRecord
         module Table
           module Testable
             module UniqueCombinationOfColumnsTestable
-              REQUIRED_UNIQUE_COMBINATION_OF_COLUMNS_TESTABLE_METHODS = %i[table_name @config].freeze
+              extend ActiveRecord::Dbt::RequiredMethods
+
+              define_required_methods :table_name, :@config
 
               delegate :used_dbt_utils?, to: :@config
-
-              REQUIRED_UNIQUE_COMBINATION_OF_COLUMNS_TESTABLE_METHODS.each do |method_name|
-                define_method(method_name) do
-                  raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
-                end
-              end
 
               def unique_combination_of_columns_test
                 return nil unless used_dbt_utils?

--- a/lib/active_record/dbt/dbt_package/dbt_utils/table/testable/unique_combination_of_columns_testable.rb
+++ b/lib/active_record/dbt/dbt_package/dbt_utils/table/testable/unique_combination_of_columns_testable.rb
@@ -13,7 +13,7 @@ module ActiveRecord
 
               REQUIRED_UNIQUE_COMBINATION_OF_COLUMNS_TESTABLE_METHODS.each do |method_name|
                 define_method(method_name) do
-                  raise NotImplementedError, "You must implement #{self.class}##{__method__}"
+                  raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
                 end
               end
 

--- a/lib/active_record/dbt/dbt_package/dbterd/column/testable/relationships_meta_relationship_type.rb
+++ b/lib/active_record/dbt/dbt_package/dbterd/column/testable/relationships_meta_relationship_type.rb
@@ -7,15 +7,11 @@ module ActiveRecord
         module Column
           module Testable
             module RelationshipsMetaRelationshipType
-              REQUIRED_RELATIONSHIP_TYPE_TESTABLE_METHODS = %i[@config foreign_key].freeze
+              extend ActiveRecord::Dbt::RequiredMethods
+
+              define_required_methods :@config, :foreign_key
 
               delegate :used_dbterd?, :add_log, to: :@config
-
-              REQUIRED_RELATIONSHIP_TYPE_TESTABLE_METHODS.each do |method_name|
-                define_method(method_name) do
-                  raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
-                end
-              end
 
               def relationships_meta_relationship_type
                 return nil unless used_dbterd?

--- a/lib/active_record/dbt/dbt_package/dbterd/column/testable/relationships_meta_relationship_type.rb
+++ b/lib/active_record/dbt/dbt_package/dbterd/column/testable/relationships_meta_relationship_type.rb
@@ -13,7 +13,7 @@ module ActiveRecord
 
               REQUIRED_RELATIONSHIP_TYPE_TESTABLE_METHODS.each do |method_name|
                 define_method(method_name) do
-                  raise NotImplementedError, "You must implement #{self.class}##{__method__}"
+                  raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
                 end
               end
 

--- a/lib/active_record/dbt/required_methods.rb
+++ b/lib/active_record/dbt/required_methods.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Dbt
+    module RequiredMethods
+      def define_required_methods(*methods)
+        methods.each do |method_name|
+          define_method(method_name) do
+            raise RequiredImplementationMissingError, "You must implement #{self.class}##{__method__}"
+          end
+        end
+      end
+
+      class RequiredImplementationMissingError < StandardError; end
+    end
+  end
+end


### PR DESCRIPTION
- Changed `NotImplementedError` to `RequiredImplementationMissingError`.
- Combine `define_method` handling in `ActiveRecord::Dbt::RequiredMethods`.

## Referenced URL

- [[Ruby]ありえない分岐には雑にraise NotImplementedErrorを置いておくと便利 #Rails - Qiita](https://qiita.com/ham0215/items/0b87f8da163f36c5147c)
- [週刊Railsウォッチ: Prismの歴史と現況を振り返る、Steepの"narrowing"実装の内部ドキュメントほか（20240426後編）｜TechRacho by BPS株式会社](https://techracho.bpsinc.jp/hachi8833/2024_04_26/141461#3-2)
- [Abstract methods and NotImplementedError in Ruby](https://nithinbekal.com/posts/abstract-methods-notimplementederror-ruby/)