### PR TITLE
Refactor ActiveRecord::Dbt::DbtPackage::Dbterd::Column::Testable::RelationshipsMetaRelationshipType

### DIFF
--- a/lib/active_record/dbt/dbt_package/dbterd/column/testable/relationships_meta_relationship_type.rb
+++ b/lib/active_record/dbt/dbt_package/dbterd/column/testable/relationships_meta_relationship_type.rb
@@ -20,7 +20,7 @@ module ActiveRecord
                 {
                   'relationship_type' => relationship_type
                 }
-              rescue NotSpecifiedOrNotInvalidIdError, StandardError => e
+              rescue NotSpecifiedOrNotInvalidIdError, NameError => e
                 relationships_meta_relationship_type_with_active_record_dbt_error(e)
               end
 

--- a/lib/active_record/dbt/dbt_package/dbterd/column/testable/relationships_meta_relationship_type.rb
+++ b/lib/active_record/dbt/dbt_package/dbterd/column/testable/relationships_meta_relationship_type.rb
@@ -14,8 +14,7 @@ module ActiveRecord
               delegate :used_dbterd?, :add_log, to: :@config
 
               def relationships_meta_relationship_type
-                return nil unless used_dbterd?
-                return nil if no_relationship?
+                return nil if !used_dbterd? || no_relationship?
 
                 {
                   'relationship_type' => relationship_type


### PR DESCRIPTION
https://codeclimate.com/github/yamotech/activerecord-dbt/issues?category=complexity&engine_name%5B%5D=structure&engine_name%5B%5D=duplication

> Method relationships_meta_relationship_type has a Cognitive Complexity of 6 (exceeds 5 allowed). Consider refactoring. 