### PR TITLE
Rename `tests:` to `data_tests:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## [Unreleased]
 
+- Rename `tests:` to `data_tests:`
+
 ## [0.3.0] - 2024-08-14
 
-- Generate seed enum files for dbt from the specified `TABLE_NAME` and `ENUM_COLUMN_NAME`.
+- Generate seed enum files for dbt from the specified `TABLE_NAME` and `ENUM_COLUMN_NAME`
 
 ## [0.2.0] - 2024-08-03
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ table_overrides:
         period: day
     columns:
       created_at:
-        tests:
+        data_tests:
           - not_null:
               where: 'id != 1'
 
@@ -251,7 +251,7 @@ table_overrides:
         period: day
     columns:
       created_at:
-        tests:
+        data_tests:
           - not_null:
               where: 'id != 1'
 
@@ -318,7 +318,7 @@ sources:
     - name: key
       description: Key
       data_type: string
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: value
@@ -327,12 +327,12 @@ sources:
     - name: created_at
       description: Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: updated_at
       description: Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
   - name: companies
     description: Write a logical_name of the 'companies' table.
@@ -340,13 +340,13 @@ sources:
     - name: id
       description: id
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: name
       description: Write a description of the 'companies.name' column.
       data_type: string
-      tests:
+      data_tests:
       - not_null
     - name: establishment_date
       description: Write a description of the 'companies.establishment_date' column.
@@ -357,7 +357,7 @@ sources:
     - name: published
       description: Write a description of the 'companies.published' column.
       data_type: bool
-      tests:
+      data_tests:
       - not_null
       - accepted_values:
           values:
@@ -367,12 +367,12 @@ sources:
     - name: created_at
       description: Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: updated_at
       description: Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
   - name: posts
     description: Post
@@ -380,13 +380,13 @@ sources:
     - name: id
       description: ID
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: user_id
       description: User
       data_type: int64
-      tests:
+      data_tests:
       - not_null
       - relationships:
           to: source('dummy', 'users')
@@ -402,17 +402,17 @@ sources:
     - name: created_at
       description: Post Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: updated_at
       description: Post Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: status
       description: Write a description of the 'posts.status' column.
       data_type: int64
-      tests:
+      data_tests:
       - accepted_values:
           values:
           - 0
@@ -421,7 +421,7 @@ sources:
           quote: false
   - name: posts_tags
     description: Write a logical_name of the 'posts_tags' table.
-    tests:
+    data_tests:
     - dbt_utils.unique_combination_of_columns:
         combination_of_columns:
         - post_id
@@ -430,7 +430,7 @@ sources:
     - name: post_id
       description: post_id
       data_type: int64
-      tests:
+      data_tests:
       - not_null
       - relationships:
           to: source('dummy', 'posts')
@@ -443,7 +443,7 @@ sources:
     - name: tag_id
       description: tag_id
       data_type: int64
-      tests:
+      data_tests:
       - not_null
       - relationships:
           to: source('dummy', 'tags')
@@ -459,13 +459,13 @@ sources:
     - name: id
       description: id
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: user_id
       description: user_id
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
       - relationships:
@@ -476,26 +476,26 @@ sources:
     - name: first_name
       description: Write a description of the 'profiles.first_name' column.
       data_type: string
-      tests:
+      data_tests:
       - not_null
     - name: last_name
       description: Write a description of the 'profiles.last_name' column.
       data_type: string
-      tests:
+      data_tests:
       - not_null
     - name: created_at
       description: Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: updated_at
       description: Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
   - name: relationships
     description: Write a logical_name of the 'relationships' table.
-    tests:
+    data_tests:
     - dbt_utils.unique_combination_of_columns:
         combination_of_columns:
         - follower_id
@@ -504,13 +504,13 @@ sources:
     - name: id
       description: id
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: follower_id
       description: follower_id
       data_type: int64
-      tests:
+      data_tests:
       - not_null
       - relationships:
           to: source('dummy', 'users')
@@ -520,7 +520,7 @@ sources:
     - name: followed_id
       description: followed_id
       data_type: int64
-      tests:
+      data_tests:
       - not_null
       - relationships:
           to: source('dummy', 'users')
@@ -530,12 +530,12 @@ sources:
     - name: created_at
       description: Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: updated_at
       description: Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
   - name: schema_migrations
     description: |-
@@ -546,7 +546,7 @@ sources:
     - name: version
       description: The version number of the migration.
       data_type: string
-      tests:
+      data_tests:
       - unique
       - not_null
   - name: tags
@@ -555,28 +555,28 @@ sources:
     - name: id
       description: id
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: name
       description: Write a description of the 'tags.name' column.
       data_type: string
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: created_at
       description: Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: updated_at
       description: Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
   - name: user_tags
     description: Write a logical_name of the 'user_tags' table.
-    tests:
+    data_tests:
     - dbt_utils.unique_combination_of_columns:
         combination_of_columns:
         - user_id
@@ -585,13 +585,13 @@ sources:
     - name: id
       description: id
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: user_id
       description: user_id
       data_type: int64
-      tests:
+      data_tests:
       - not_null
       - relationships:
           to: source('dummy', 'users')
@@ -601,7 +601,7 @@ sources:
     - name: tag_id
       description: tag_id
       data_type: int64
-      tests:
+      data_tests:
       - not_null
       - relationships:
           to: source('dummy', 'tags')
@@ -611,12 +611,12 @@ sources:
     - name: created_at
       description: Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: updated_at
       description: Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
   - name: users
     description: User
@@ -632,24 +632,24 @@ sources:
     - name: id
       description: ID
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: created_at
       description: User Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null:
           where: id != 1
     - name: updated_at
       description: User Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: company_id
       description: company_id
       data_type: int64
-      tests:
+      data_tests:
       - relationships:
           to: source('dummy', 'companies')
           field: id
@@ -846,7 +846,7 @@ models:
   - name: profile_id
     description: profile_id
     data_type: int64
-    tests:
+    data_tests:
     - unique
     - not_null
     - relationships:
@@ -857,7 +857,7 @@ models:
   - name: user_id
     description: user_id
     data_type: int64
-    tests:
+    data_tests:
     - unique
     - not_null
     - relationships:
@@ -868,22 +868,22 @@ models:
   - name: first_name
     description: Write a description of the 'profiles.first_name' column.
     data_type: string
-    tests:
+    data_tests:
     - not_null
   - name: last_name
     description: Write a description of the 'profiles.last_name' column.
     data_type: string
-    tests:
+    data_tests:
     - not_null
   - name: created_at
     description: Created At
     data_type: datetime
-    tests:
+    data_tests:
     - not_null
   - name: updated_at
     description: Updated At
     data_type: datetime
-    tests:
+    data_tests:
     - not_null
 
 ```
@@ -977,22 +977,22 @@ seeds:
 columns:
 - name: status_before_type_of_cast
   description: Status
-  tests:
+  data_tests:
   - unique
   - not_null
 - name: status_key
   description: Status(key)
-  tests:
+  data_tests:
   - unique
   - not_null
 - name: status_en
   description: Status(en)
-  tests:
+  data_tests:
   - unique
   - not_null
 - name: status_ja
   description: Status(ja)
-  tests:
+  data_tests:
   - unique
   - not_null
 

--- a/README.md
+++ b/README.md
@@ -298,6 +298,14 @@ Generate `#{export_directory_path}/src_#{source_name}.yml`.
 >
 > The output will be as shown below. It is recommended to indent the YAML file with a tool of your choice.
 
+> [!WARNING]
+>
+> If you are using a version of dbt lower than v1.8, replace `tests:` with `data_tests:` in the generated file.
+>
+> [Add data tests to your DAG | dbt Developer Hub](https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax)
+>
+>> Data tests were historically called "tests" in dbt as the only form of testing available. With the introduction of unit tests in v1.8, the key was renamed from `tests:` to `data_tests:`.
+
 ```yaml
 ---
 version: 2
@@ -836,6 +844,14 @@ Example:
 >
 > The output will be as shown below. It is recommended to indent the YAML file with a tool of your choice.
 
+> [!WARNING]
+>
+> If you are using a version of dbt lower than v1.8, replace `tests:` with `data_tests:` in the generated file.
+>
+> [Add data tests to your DAG | dbt Developer Hub](https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax)
+>
+>> Data tests were historically called "tests" in dbt as the only form of testing available. With the introduction of unit tests in v1.8, the key was renamed from `tests:` to `data_tests:`.
+
 ```yaml
 ---
 version: 2
@@ -961,6 +977,14 @@ Example:
 > [!NOTE]
 >
 > The output will be as shown below. It is recommended to indent the YAML file with a tool of your choice.
+
+> [!WARNING]
+>
+> If you are using a version of dbt lower than v1.8, replace `tests:` with `data_tests:` in the generated file.
+>
+> [Add data tests to your DAG | dbt Developer Hub](https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax)
+>
+>> Data tests were historically called "tests" in dbt as the only form of testing available. With the introduction of unit tests in v1.8, the key was renamed from `tests:` to `data_tests:`.
 
 ```yaml
 ---

--- a/lib/active_record/dbt/column/column.rb
+++ b/lib/active_record/dbt/column/column.rb
@@ -25,8 +25,8 @@ module ActiveRecord
             'name' => column_name,
             'description' => description,
             'data_type' => data_type(column.type),
-            **column_overrides.except(:tests),
-            'tests' => column_test.config
+            **column_overrides.except(:data_tests),
+            'data_tests' => column_test.config
           }.compact
         end
 

--- a/lib/active_record/dbt/column/test.rb
+++ b/lib/active_record/dbt/column/test.rb
@@ -23,14 +23,14 @@ module ActiveRecord
         end
 
         def config
-          (tests.keys | tests_overrides_hash.keys).map do |key|
-            tests_overrides_hash[key] || tests[key]
+          (data_tests.keys | data_tests_overrides_hash.keys).map do |key|
+            data_tests_overrides_hash[key] || data_tests[key]
           end.presence
         end
 
         private
 
-        def tests
+        def data_tests
           {
             'unique_test' => unique_test,
             'not_null_test' => not_null_test,
@@ -39,10 +39,10 @@ module ActiveRecord
           }.compact
         end
 
-        def tests_overrides_hash
-          @tests_overrides_hash ||=
-            tests_overrides.index_by do |tests_override|
-              "#{extract_key(tests_override)}_test"
+        def data_tests_overrides_hash
+          @data_tests_overrides_hash ||=
+            data_tests_overrides.index_by do |data_tests_override|
+              "#{extract_key(data_tests_override)}_test"
             end
         end
 
@@ -50,9 +50,9 @@ module ActiveRecord
           item.is_a?(Hash) ? item.keys.first : item
         end
 
-        def tests_overrides
-          @tests_overrides ||=
-            source_config.dig(:table_overrides, table_name, :columns, column_name, :tests) ||
+        def data_tests_overrides
+          @data_tests_overrides ||=
+            source_config.dig(:table_overrides, table_name, :columns, column_name, :data_tests) ||
             []
         end
       end

--- a/lib/active_record/dbt/model/staging/yml.rb
+++ b/lib/active_record/dbt/model/staging/yml.rb
@@ -79,7 +79,7 @@ module ActiveRecord
           end
 
           def add_relationship_test(column)
-            column['tests'].push(relationships_test(column['name']))
+            column['data_tests'].push(relationships_test(column['name']))
           end
 
           def rename_primary_id_in_column(column)

--- a/lib/active_record/dbt/seed/enum/yml.rb
+++ b/lib/active_record/dbt/seed/enum/yml.rb
@@ -81,7 +81,7 @@ module ActiveRecord
             {
               'name' => "#{enum_column_name}_before_type_of_cast",
               'description' => translated_attribute_name,
-              'tests' => tests
+              'data_tests' => data_tests
             }.compact
           end
 
@@ -89,7 +89,7 @@ module ActiveRecord
             {
               'name' => "#{enum_column_name}_key",
               'description' => "#{translated_attribute_name}(key)",
-              'tests' => tests
+              'data_tests' => data_tests
             }.compact
           end
 
@@ -99,13 +99,13 @@ module ActiveRecord
                 {
                   'name' => "#{enum_column_name}_#{locale}",
                   'description' => "#{translated_attribute_name}(#{locale})",
-                  'tests' => tests
+                  'data_tests' => data_tests
                 }.compact
               )
             end
           end
 
-          def tests
+          def data_tests
             [
               unique_test,
               not_null_test

--- a/lib/active_record/dbt/table/yml.rb
+++ b/lib/active_record/dbt/table/yml.rb
@@ -31,7 +31,7 @@ module ActiveRecord
             'name' => table_name,
             'description' => description,
             **table_overrides.except(:columns),
-            'tests' => table_test.config
+            'data_tests' => table_test.config
           }
         end
 

--- a/lib/generators/active_record/dbt/config/templates/source_config.yml.tt
+++ b/lib/generators/active_record/dbt/config/templates/source_config.yml.tt
@@ -11,7 +11,7 @@ table_overrides:
     meta: {<dictionary>}
     identifier: <table_name>
     loaded_at_field: <column_name>
-    tests:
+    data_tests:
       - <test>
     tags: [<string>]
     freshness:
@@ -31,7 +31,7 @@ table_overrides:
       <column_name>:
         meta: {<dictionary>}
         quote: true | false
-        tests:
+        data_tests:
           - <test>
         tags: [<string>]
 

--- a/spec/dummy/doc/dbt/seed_dummy__post_enum_statuses.yml
+++ b/spec/dummy/doc/dbt/seed_dummy__post_enum_statuses.yml
@@ -12,21 +12,21 @@ seeds:
 columns:
 - name: status_before_type_of_cast
   description: Status
-  tests:
+  data_tests:
   - unique
   - not_null
 - name: status_key
   description: Status(key)
-  tests:
+  data_tests:
   - unique
   - not_null
 - name: status_en
   description: Status(en)
-  tests:
+  data_tests:
   - unique
   - not_null
 - name: status_ja
   description: Status(ja)
-  tests:
+  data_tests:
   - unique
   - not_null

--- a/spec/dummy/doc/dbt/src_dummy.yml
+++ b/spec/dummy/doc/dbt/src_dummy.yml
@@ -17,7 +17,7 @@ sources:
     - name: key
       description: Key
       data_type: string
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: value
@@ -26,12 +26,12 @@ sources:
     - name: created_at
       description: Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: updated_at
       description: Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
   - name: companies
     description: Write a logical_name of the 'companies' table.
@@ -39,13 +39,13 @@ sources:
     - name: id
       description: id
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: name
       description: Write a description of the 'companies.name' column.
       data_type: string
-      tests:
+      data_tests:
       - not_null
     - name: establishment_date
       description: Write a description of the 'companies.establishment_date' column.
@@ -56,7 +56,7 @@ sources:
     - name: published
       description: Write a description of the 'companies.published' column.
       data_type: bool
-      tests:
+      data_tests:
       - not_null
       - accepted_values:
           values:
@@ -66,12 +66,12 @@ sources:
     - name: created_at
       description: Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: updated_at
       description: Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
   - name: posts
     description: Post
@@ -79,13 +79,13 @@ sources:
     - name: id
       description: ID
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: user_id
       description: User
       data_type: int64
-      tests:
+      data_tests:
       - not_null
       - relationships:
           to: source('dummy', 'users')
@@ -101,17 +101,17 @@ sources:
     - name: created_at
       description: Post Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: updated_at
       description: Post Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: status
       description: Status
       data_type: int64
-      tests:
+      data_tests:
       - accepted_values:
           values:
           - 0
@@ -120,7 +120,7 @@ sources:
           quote: false
   - name: posts_tags
     description: Write a logical_name of the 'posts_tags' table.
-    tests:
+    data_tests:
     - dbt_utils.unique_combination_of_columns:
         combination_of_columns:
         - post_id
@@ -129,7 +129,7 @@ sources:
     - name: post_id
       description: post_id
       data_type: int64
-      tests:
+      data_tests:
       - not_null
       - relationships:
           to: source('dummy', 'posts')
@@ -142,7 +142,7 @@ sources:
     - name: tag_id
       description: tag_id
       data_type: int64
-      tests:
+      data_tests:
       - not_null
       - relationships:
           to: source('dummy', 'tags')
@@ -158,13 +158,13 @@ sources:
     - name: id
       description: id
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: user_id
       description: user_id
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
       - relationships:
@@ -175,26 +175,26 @@ sources:
     - name: first_name
       description: Write a description of the 'profiles.first_name' column.
       data_type: string
-      tests:
+      data_tests:
       - not_null
     - name: last_name
       description: Write a description of the 'profiles.last_name' column.
       data_type: string
-      tests:
+      data_tests:
       - not_null
     - name: created_at
       description: Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: updated_at
       description: Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
   - name: relationships
     description: Write a logical_name of the 'relationships' table.
-    tests:
+    data_tests:
     - dbt_utils.unique_combination_of_columns:
         combination_of_columns:
         - follower_id
@@ -203,13 +203,13 @@ sources:
     - name: id
       description: id
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: follower_id
       description: follower_id
       data_type: int64
-      tests:
+      data_tests:
       - not_null
       - relationships:
           to: source('dummy', 'users')
@@ -219,7 +219,7 @@ sources:
     - name: followed_id
       description: followed_id
       data_type: int64
-      tests:
+      data_tests:
       - not_null
       - relationships:
           to: source('dummy', 'users')
@@ -229,12 +229,12 @@ sources:
     - name: created_at
       description: Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: updated_at
       description: Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
   - name: schema_migrations
     description: |-
@@ -245,7 +245,7 @@ sources:
     - name: version
       description: The version number of the migration.
       data_type: string
-      tests:
+      data_tests:
       - unique
       - not_null
   - name: tags
@@ -254,28 +254,28 @@ sources:
     - name: id
       description: id
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: name
       description: Write a description of the 'tags.name' column.
       data_type: string
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: created_at
       description: Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: updated_at
       description: Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
   - name: user_tags
     description: Write a logical_name of the 'user_tags' table.
-    tests:
+    data_tests:
     - dbt_utils.unique_combination_of_columns:
         combination_of_columns:
         - user_id
@@ -284,13 +284,13 @@ sources:
     - name: id
       description: id
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: user_id
       description: user_id
       data_type: int64
-      tests:
+      data_tests:
       - not_null
       - relationships:
           to: source('dummy', 'users')
@@ -300,7 +300,7 @@ sources:
     - name: tag_id
       description: tag_id
       data_type: int64
-      tests:
+      data_tests:
       - not_null
       - relationships:
           to: source('dummy', 'tags')
@@ -310,12 +310,12 @@ sources:
     - name: created_at
       description: Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: updated_at
       description: Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
   - name: users
     description: User
@@ -331,24 +331,24 @@ sources:
     - name: id
       description: ID
       data_type: int64
-      tests:
+      data_tests:
       - unique
       - not_null
     - name: created_at
       description: User Created At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null:
           where: id != 1
     - name: updated_at
       description: User Updated At
       data_type: datetime
-      tests:
+      data_tests:
       - not_null
     - name: company_id
       description: company_id
       data_type: int64
-      tests:
+      data_tests:
       - relationships:
           to: source('dummy', 'companies')
           field: id

--- a/spec/dummy/doc/dbt/stg_dummy__posts.yml
+++ b/spec/dummy/doc/dbt/stg_dummy__posts.yml
@@ -7,7 +7,7 @@ models:
   - name: post_id
     description: ID
     data_type: int64
-    tests:
+    data_tests:
     - unique
     - not_null
     - relationships:
@@ -18,7 +18,7 @@ models:
   - name: user_id
     description: User
     data_type: int64
-    tests:
+    data_tests:
     - not_null
     - relationships:
         to: source('dummy', 'users')
@@ -28,7 +28,7 @@ models:
   - name: status
     description: Status
     data_type: int64
-    tests:
+    data_tests:
     - accepted_values:
         values:
         - 0
@@ -44,10 +44,10 @@ models:
   - name: created_at
     description: Post Created At
     data_type: datetime
-    tests:
+    data_tests:
     - not_null
   - name: updated_at
     description: Post Updated At
     data_type: datetime
-    tests:
+    data_tests:
     - not_null

--- a/spec/dummy/doc/dbt/stg_dummy__profiles.yml
+++ b/spec/dummy/doc/dbt/stg_dummy__profiles.yml
@@ -7,7 +7,7 @@ models:
   - name: profile_id
     description: profile_id
     data_type: int64
-    tests:
+    data_tests:
     - unique
     - not_null
     - relationships:
@@ -18,7 +18,7 @@ models:
   - name: user_id
     description: user_id
     data_type: int64
-    tests:
+    data_tests:
     - unique
     - not_null
     - relationships:
@@ -29,20 +29,20 @@ models:
   - name: first_name
     description: Write a description of the 'profiles.first_name' column.
     data_type: string
-    tests:
+    data_tests:
     - not_null
   - name: last_name
     description: Write a description of the 'profiles.last_name' column.
     data_type: string
-    tests:
+    data_tests:
     - not_null
   - name: created_at
     description: Created At
     data_type: datetime
-    tests:
+    data_tests:
     - not_null
   - name: updated_at
     description: Updated At
     data_type: datetime
-    tests:
+    data_tests:
     - not_null

--- a/spec/dummy/lib/dbt/source_config.yml
+++ b/spec/dummy/lib/dbt/source_config.yml
@@ -18,7 +18,7 @@ table_overrides:
         period: day
     columns:
       created_at:
-        tests:
+        data_tests:
           - not_null:
               where: 'id != 1'
 


### PR DESCRIPTION
[Add data tests to your DAG | dbt Developer Hub](https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax)

> Data tests were historically called "tests" in dbt as the only form of testing available. With the introduction of unit tests in v1.8, the key was renamed from `tests:` to `data_tests:`.