### PR TITLE
Fix ArgumentError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Rename `tests:` to `data_tests:`
 - Change output destination from `#{export_directory_path}/*.*` to `#{export_directory_path}/**/*.*`
 - Rename `#config` to `#properties`
+- Fix `ArgumentError`
 
 ## [0.3.0] - 2024-08-14
 

--- a/lib/active_record/dbt/dbt_package/dbterd/column/testable/relationships_meta_relationship_type.rb
+++ b/lib/active_record/dbt/dbt_package/dbterd/column/testable/relationships_meta_relationship_type.rb
@@ -89,7 +89,7 @@ module ActiveRecord
               end
 
               def association_klass(association)
-                association.klass
+                association.class_name.constantize
               rescue NoMethodError
                 association.options.fetch(:through).to_s.classify.constantize
               end


### PR DESCRIPTION
```shell
$ bin/rails generate active_record:dbt:source

...

/usr/local/bundle/gems/activerecord-7.0.8.4/lib/active_record/reflection.rb:436:in `compute_class': Rails couldn't find a valid model for HogeHoge association. Please provide the :class_name option on the association declaration. If :class_name is already provided, make sure it's an ActiveRecord::Base subclass. (ArgumentError)

            raise ArgumentError, msg
                  ^^^^^^^^^^^^^^^^^^
	from /usr/local/bundle/gems/activerecord-7.0.8.4/lib/active_record/reflection.rb:382:in `klass'

...
```