### PR TITLE
Fix `No matching signature for operator IN for argument types INT64 and {BOOL} at []`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fix column order in `stg_*.yml`
+- Fix `No matching signature for operator IN for argument types INT64 and {BOOL} at []`
 
 ## [0.4.0] - 2024-09-01
 

--- a/lib/active_record/dbt/column/yml.rb
+++ b/lib/active_record/dbt/column/yml.rb
@@ -7,6 +7,8 @@ module ActiveRecord
         include ActiveRecord::Dbt::DataType::Mapper
         include ActiveRecord::Dbt::I18nWrapper::Translate
 
+        using ActiveRecord::Dbt::CoreExt::ActiveRecordExt
+
         attr_reader :table_name, :column, :column_data_test, :primary_keys
 
         delegate :name, :comment, to: :column, prefix: true

--- a/lib/active_record/dbt/core_ext/active_record_ext.rb
+++ b/lib/active_record/dbt/core_ext/active_record_ext.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Dbt
+    module CoreExt
+      module ActiveRecordExt
+        if defined?(ActiveRecord::ConnectionAdapters::MySQL::Column)
+          refine ActiveRecord::ConnectionAdapters::MySQL::Column do
+            def type
+              sql_type == 'tinyint(1)' ? :integer : super
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/dbt/model/staging/base.rb
+++ b/lib/active_record/dbt/model/staging/base.rb
@@ -5,6 +5,8 @@ module ActiveRecord
     module Model
       module Staging
         module Base
+          using ActiveRecord::Dbt::CoreExt::ActiveRecordExt
+
           SORT_COLUMN_TYPES = %w[
             ids enums
             strings texts


### PR DESCRIPTION
## Error

```shell
Database Error in test source_accepted_values_#{source_name}_#{table_name}_#{column_name}__False__True__False (models/sources/#{source_name}/src_#{source_name}.yml)
  No matching signature for operator IN for argument types INT64 and {BOOL} at []
  compiled Code at target/run/...
```