### PR TITLE
Fix `gsub': no implicit conversion of nil into String (TypeError)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix `Syntax error: Unexpected keyword GROUP at []`
 - Fix `dbt_utils.unique_combination_of_columns`
 - Swap `translated_column_name` and `translated_attribute_name`
+- Fix `gsub': no implicit conversion of nil into String (TypeError)`
 
 ## [0.4.0] - 2024-09-01
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ defaults:
       description: Write a description of the '{{ table_name }}.{{ column_name }}' column.
   seed_descriptions:
     enum:
-      description: "{{ source_name }} {{ translated_table_name }} {{ column_description }} enum"
+      description: "{{ source_name }} {{ logical_name }} {{ column_description }} enum"
 
 table_descriptions:
   ar_internal_metadata:
@@ -896,7 +896,7 @@ You can configure `defaults` in this file.
 
 Set the default value for the `description` of the `seeds` enum.
 
-In the `description` of `seed_descriptions.enum`, you can refer to the source name with `{{ source_name }}`, the translated table name with `{{ translated_table_name }}`, and the column description with `{{ column_description }}`.
+In the `description` of `seed_descriptions.enum`, you can refer to the source name with `{{ source_name }}`, the logical table name with `{{ logical_name }}`, and the column description with `{{ column_description }}`.
 
 Example:
 
@@ -904,7 +904,7 @@ Example:
 defaults:
   seed_descriptions:
     enum:
-      description: "{{ source_name }} {{ translated_table_name }} {{ column_description }} enum"
+      description: "{{ source_name }} {{ logical_name }} {{ column_description }} enum"
 
 ```
 
@@ -914,7 +914,7 @@ If nothing is set, it defaults to the following:
 defaults:
   seed_descriptions:
     enum:
-      description: "{{ source_name }} {{ translated_table_name }} {{ column_description }} enum"
+      description: "{{ source_name }} {{ logical_name }} {{ column_description }} enum"
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ defaults:
       description: Write a description of the '{{ table_name }}.{{ column_name }}' column.
   seed_descriptions:
     enum:
-      description: "{{ source_name }} {{ translated_table_name }} {{ translated_column_name }} enum"
+      description: "{{ source_name }} {{ translated_table_name }} {{ column_description }} enum"
 
 table_descriptions:
   ar_internal_metadata:
@@ -896,7 +896,7 @@ You can configure `defaults` in this file.
 
 Set the default value for the `description` of the `seeds` enum.
 
-In the `description` of `seed_descriptions.enum`, you can refer to the source name with `{{ source_name }}`, the translated table name with `{{ translated_table_name }}`, and the translated column name with `{{ translated_column_name }}`.
+In the `description` of `seed_descriptions.enum`, you can refer to the source name with `{{ source_name }}`, the translated table name with `{{ translated_table_name }}`, and the column description with `{{ column_description }}`.
 
 Example:
 
@@ -904,7 +904,7 @@ Example:
 defaults:
   seed_descriptions:
     enum:
-      description: "{{ source_name }} {{ translated_table_name }} {{ translated_column_name }} enum"
+      description: "{{ source_name }} {{ translated_table_name }} {{ column_description }} enum"
 
 ```
 
@@ -914,7 +914,7 @@ If nothing is set, it defaults to the following:
 defaults:
   seed_descriptions:
     enum:
-      description: "{{ source_name }} {{ translated_table_name }} {{ translated_column_name }} enum"
+      description: "{{ source_name }} {{ translated_table_name }} {{ column_description }} enum"
 
 ```
 

--- a/lib/active_record/dbt/column/yml.rb
+++ b/lib/active_record/dbt/column/yml.rb
@@ -24,7 +24,7 @@ module ActiveRecord
         delegate :name, :comment, to: :column, prefix: true
         delegate :source_config, to: :@config
 
-        def initialize(table_name, column, column_data_test, primary_keys: [])
+        def initialize(table_name, column, column_data_test = Struct.new(:properties).new, primary_keys: [])
           @config = ActiveRecord::Dbt::Config.instance
           @table_name = validate_table_name(table_name, @config)
           @column = column
@@ -43,19 +43,23 @@ module ActiveRecord
           }.compact
         end
 
+        def column_description
+          config_column_description ||
+            translated_column_name ||
+            column_comment ||
+            key_column_name ||
+            default_column_description
+        end
+
         private
 
         def description
           @description ||=
             column_description ||
-            translated_column_name ||
-            column_comment ||
-            key_column_name ||
-            default_column_description ||
             "Write a description of the '#{table_name}.#{column_name}' column."
         end
 
-        def column_description
+        def config_column_description
           source_config.dig(:table_descriptions, table_name, :columns, column_name)
         end
 

--- a/lib/active_record/dbt/factory/enum/yml_factory.rb
+++ b/lib/active_record/dbt/factory/enum/yml_factory.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module Dbt
+    module Factory
+      module Enum
+        module YmlFactory
+          def self.build(
+            table_name,
+            column_name,
+            primary_keys: ActiveRecord::Base.connection.primary_keys(table_name)
+          )
+            column = ActiveRecord::Base.connection.columns(table_name).find{ |c| c.name == column_name }
+            enum_column = ActiveRecord::Dbt::Column::Yml.new(
+              table_name,
+              column,
+              primary_keys: primary_keys
+            )
+
+            ActiveRecord::Dbt::Seed::Enum::Yml.new(table_name, enum_column)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/dbt/factory/enum/yml_factory.rb
+++ b/lib/active_record/dbt/factory/enum/yml_factory.rb
@@ -10,6 +10,7 @@ module ActiveRecord
             column_name,
             primary_keys: ActiveRecord::Base.connection.primary_keys(table_name)
           )
+            table = ActiveRecord::Dbt::Table::Yml.new(table_name)
             column = ActiveRecord::Base.connection.columns(table_name).find{ |c| c.name == column_name }
             enum_column = ActiveRecord::Dbt::Column::Yml.new(
               table_name,
@@ -17,7 +18,7 @@ module ActiveRecord
               primary_keys: primary_keys
             )
 
-            ActiveRecord::Dbt::Seed::Enum::Yml.new(table_name, enum_column)
+            ActiveRecord::Dbt::Seed::Enum::Yml.new(table, enum_column)
           end
         end
       end

--- a/lib/active_record/dbt/table/yml.rb
+++ b/lib/active_record/dbt/table/yml.rb
@@ -11,7 +11,7 @@ module ActiveRecord
 
         delegate :source_config, to: :@config
 
-        def initialize(table_name, table_data_test, columns)
+        def initialize(table_name, table_data_test = Struct.new(:properties).new, columns = [])
           super(table_name)
           @table_data_test = table_data_test
           @columns = columns
@@ -22,6 +22,12 @@ module ActiveRecord
             **table_properties,
             'columns' => columns.map(&:properties)
           }.compact
+        end
+
+        def logical_name
+          config_logical_name ||
+            translated_table_name ||
+            default_logical_name
         end
 
         private
@@ -36,20 +42,22 @@ module ActiveRecord
         end
 
         def description
-          return logical_name if table_description.blank?
+          return table_description_title if table_description.blank?
 
           [
-            "# #{logical_name}",
+            "# #{table_description_title}",
             table_description
           ].join("\n")
         end
 
-        def logical_name
-          @logical_name ||=
-            source_config.dig(:table_descriptions, table_name, :logical_name) ||
-            translated_table_name ||
-            default_logical_name ||
+        def table_description_title
+          @table_description_title ||=
+            logical_name ||
             "Write a logical_name of the '#{table_name}' table."
+        end
+
+        def config_logical_name
+          source_config.dig(:table_descriptions, table_name, :logical_name)
         end
 
         def default_logical_name

--- a/lib/generators/active_record/dbt/config/templates/source_config.yml.tt
+++ b/lib/generators/active_record/dbt/config/templates/source_config.yml.tt
@@ -46,7 +46,7 @@ defaults:
       description: Write a description of the '{{ table_name }}.{{ column_name }}' column.
   seed_descriptions:
     enum:
-      description: "{{ source_name }} {{ translated_table_name }} {{ column_description }} enum"
+      description: "{{ source_name }} {{ logical_name }} {{ column_description }} enum"
 
 table_descriptions:
   ar_internal_metadata:

--- a/lib/generators/active_record/dbt/config/templates/source_config.yml.tt
+++ b/lib/generators/active_record/dbt/config/templates/source_config.yml.tt
@@ -46,7 +46,7 @@ defaults:
       description: Write a description of the '{{ table_name }}.{{ column_name }}' column.
   seed_descriptions:
     enum:
-      description: "{{ source_name }} {{ translated_table_name }} {{ translated_column_name }} enum"
+      description: "{{ source_name }} {{ translated_table_name }} {{ column_description }} enum"
 
 table_descriptions:
   ar_internal_metadata:

--- a/lib/generators/active_record/dbt/enum/enum_generator.rb
+++ b/lib/generators/active_record/dbt/enum/enum_generator.rb
@@ -23,7 +23,7 @@ module ActiveRecord
         end
 
         def yml
-          @yml ||= ActiveRecord::Dbt::Seed::Enum::Yml.new(name, enum_column_name)
+          @yml ||= ActiveRecord::Dbt::Factory::Enum::YmlFactory.build(name, enum_column_name)
         end
       end
     end

--- a/spec/dummy/lib/dbt/source_config.yml
+++ b/spec/dummy/lib/dbt/source_config.yml
@@ -32,7 +32,7 @@ defaults:
       description: Write a description of the '{{ table_name }}.{{ column_name }}' column.
   seed_descriptions:
     enum:
-      description: "{{ source_name }} {{ translated_table_name }} {{ translated_column_name }} enum"
+      description: "{{ source_name }} {{ translated_table_name }} {{ column_description }} enum"
 
 table_descriptions:
   ar_internal_metadata:

--- a/spec/dummy/lib/dbt/source_config.yml
+++ b/spec/dummy/lib/dbt/source_config.yml
@@ -32,7 +32,7 @@ defaults:
       description: Write a description of the '{{ table_name }}.{{ column_name }}' column.
   seed_descriptions:
     enum:
-      description: "{{ source_name }} {{ translated_table_name }} {{ column_description }} enum"
+      description: "{{ source_name }} {{ logical_name }} {{ column_description }} enum"
 
 table_descriptions:
   ar_internal_metadata:


### PR DESCRIPTION
```ruby
/activerecord-dbt/lib/active_record/dbt/seed/enum/yml.rb:52:in `gsub': no implicit conversion of nil into String (TypeError)

                         &.gsub(/{{\s*translated_table_name\s*}}/, translated_table_name)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```