### PR TITLE
Replaced `YAML.load_file` with `YAML.safe_load_file` to prevent potential arbitrary code execution when loading configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- None
+- Replace `YAML.load_file` with `YAML.safe_load_file` to prevent potential arbitrary code execution when loading configuration files
 
 ## [0.5.0] - 2026-01-18
 

--- a/lib/active_record/dbt/configuration/parser.rb
+++ b/lib/active_record/dbt/configuration/parser.rb
@@ -7,7 +7,7 @@ module ActiveRecord
         def parse_yaml(path)
           return {} if path.nil?
 
-          YAML.safe_load_file(path).with_indifferent_access || {}
+          YAML.safe_load_file(path)&.with_indifferent_access || {}
         end
       end
     end

--- a/lib/active_record/dbt/configuration/parser.rb
+++ b/lib/active_record/dbt/configuration/parser.rb
@@ -7,7 +7,7 @@ module ActiveRecord
         def parse_yaml(path)
           return {} if path.nil?
 
-          YAML.load_file(path).with_indifferent_access || {}
+          YAML.safe_load_file(path).with_indifferent_access || {}
         end
       end
     end


### PR DESCRIPTION
This pull request improves the security of configuration file loading by replacing the potentially unsafe `YAML.load_file` with `YAML.safe_load_file`. This change helps prevent arbitrary code execution vulnerabilities when parsing YAML files.

Security improvements:

* Replaced `YAML.load_file` with `YAML.safe_load_file` in the `parse_yaml` method in `lib/active_record/dbt/configuration/parser.rb` to ensure safer loading of YAML configuration files.
* Updated the `CHANGELOG.md` to document the replacement of `YAML.load_file` with `YAML.safe_load_file` for improved security.